### PR TITLE
Allow free dishes

### DIFF
--- a/app/models/dish.rb
+++ b/app/models/dish.rb
@@ -9,6 +9,7 @@ class Dish < ActiveRecord::Base
                    uniqueness: {scope: :order_id,
                                 message: 'can only order one dish'}
   validates :order, :price_cents, presence: true
+  validates :price_cents, numericality: {greater_than_or_equal_to: 0}
 
   register_currency :pln
   monetize :price_cents

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,6 +46,7 @@ class User < ActiveRecord::Base
 
   def subtract(amount, payer)
     return if self == payer && !subtract_from_self
+    return if amount == 0
     user_balances.create(balance: payer_balance(payer) - amount, payer: payer)
     received_payments.create!(balance: amount, payer: payer)
   end

--- a/spec/models/dish_spec.rb
+++ b/spec/models/dish_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe Dish, type: :model do
     expect(monetize(:price_cents)).to be_truthy
   end
 
+  it 'should validate positive price' do
+    dish.price_cents = 0
+    expect(dish.valid?).to be_truthy
+    dish.price_cents = -100
+    expect(dish.valid?).to be_falsey
+  end
+
   describe '#copy' do
     it 'returns an instance of dish' do
       expect(new_dish.user).to eq(other_user)

--- a/spec/models/dish_spec.rb
+++ b/spec/models/dish_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Dish, type: :model do
     expect(monetize(:price_cents)).to be_truthy
   end
 
-  it 'should validate positive price' do
+  it 'validates price positivity' do
     dish.price_cents = 0
     expect(dish.valid?).to be_truthy
     dish.price_cents = -100


### PR DESCRIPTION
New model validates that `Payment`'s amount is greater than 0. And that's great but we might want some free dishes from time to time. In such case no substraction should happen. I'm gonna YOLO merge, but please take a look @grodowski 